### PR TITLE
add a new arg log-format to support json log output

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -95,7 +95,7 @@ func TestHandlerMissingAmzDate(t *testing.T) {
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 	assert.Equal(t, 400, resp.Code)
-	assert.Contains(t, resp.Body.String(), "X-Amz-Date header missing or set multiple times")
+	assert.Contains(t, resp.Body.String(), "X-Amz-Date query parameter or header missing")
 }
 
 func TestHandlerMissingAuthorization(t *testing.T) {
@@ -106,7 +106,7 @@ func TestHandlerMissingAuthorization(t *testing.T) {
 	resp := httptest.NewRecorder()
 	h.ServeHTTP(resp, req)
 	assert.Equal(t, 400, resp.Code)
-	assert.Contains(t, resp.Body.String(), "Authorization header missing or set multiple times")
+	assert.Contains(t, resp.Body.String(), "X-Amz-Credential query parameter or Authorization header missing")
 }
 
 func TestHandlerMissingCredential(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type Options struct {
 	UpstreamEndpoint      string
 	CertFile              string
 	KeyFile               string
+	LogFormat             string
 }
 
 // NewOptions defines and parses the raw command line arguments
@@ -47,6 +48,8 @@ func NewOptions() Options {
 	kingpin.Flag("upstream-endpoint", "use this S3 endpoint for upstream connections, instead of public AWS S3 (env - UPSTREAM_ENDPOINT)").Envar("UPSTREAM_ENDPOINT").StringVar(&opts.UpstreamEndpoint)
 	kingpin.Flag("cert-file", "path to the certificate file (env - CERT_FILE)").Envar("CERT_FILE").Default("").StringVar(&opts.CertFile)
 	kingpin.Flag("key-file", "path to the private key file (env - KEY_FILE)").Envar("KEY_FILE").Default("").StringVar(&opts.KeyFile)
+	kingpin.Flag("log-format", "output format of logs, either text (default) or json (env - LOG_FORMAT)").Envar("LOG_FORMAT").Default("text").EnumVar(&opts.LogFormat, "text", "json")
+
 	kingpin.Parse()
 	return opts
 }
@@ -57,6 +60,11 @@ func NewAwsS3ReverseProxy(opts Options) (*Handler, error) {
 	if opts.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
+  // text is the default format for sirupsen/logrus
+  // and requires no explicit SetFormatter() call
+  if opts.LogFormat == "json" {
+    log.SetFormatter(&log.JSONFormatter{})
+  }
 
 	scheme := "https"
 	if opts.UpstreamInsecure {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ func TestParseOptions(t *testing.T) {
 		AllowedSourceSubnet:   []string{"127.0.0.1/32", "192.168.1.0/24"},
 		AwsCredentials:        []string{"fooooooooooooooo,bar", "baaaaaaaaaaaaaar,baz"},
 		Region:                "eu-test-1",
+		LogFormat:             "json",
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, "https", h.UpstreamScheme)


### PR DESCRIPTION
part of https://fivetran.atlassian.net/browse/RD-447438

I have also fixed a few broken tests and added the new arg into existing tests. They all work perfectly in local testing

```
➜  aws-s3-reverse-proxy git:(json-log) go test
...

PASS
ok  	github.com/Kriechi/aws-s3-reverse-proxy	0.222s
```

@pjankovsky We should consider adding a github action to run tests on every commit